### PR TITLE
Fixing link to the api documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 - [Installation](#installation)
 - [Usage](#usage)
-- [API](/api.md)
+- [API](/docs/api.md)
 
 ## Installation
 


### PR DESCRIPTION
My attempt at fixing the issue I submitted: [#12](https://github.com/picodom/picodom/issues/12)