### PR TITLE
Proof of concept for `context` idea

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -1,5 +1,10 @@
 var i
 var stack = []
+var context = null
+
+export function setContext(x) {
+  context = x
+}
 
 export function h(tag, data) {
   var node
@@ -28,5 +33,5 @@ export function h(tag, data) {
         data: data || {},
         children: children
       }
-    : tag(data, children)
+    : tag(data, children, context)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { h } from "./h"
+export { h, setContext } from "./h"
 export { default as patch } from "./patch"

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -1,4 +1,4 @@
-import { h } from "../src"
+import { h, setContext } from "../src"
 
 test("empty vnode", () => {
   expect(h("div")).toEqual({
@@ -98,6 +98,30 @@ test("components", () => {
         tag: "div",
         data: { id: "bar" },
         children: []
+      }
+    ]
+  })
+})
+
+test("components with context", () => {
+  const Component = (data, children, context) => {
+    return context != null ?
+      h(context.foo, data, children) :
+      h("div", data, children)
+  }
+
+  expect(h((data, children, context) => context)).toEqual(null)
+
+  setContext({ foo: "p" })
+
+  expect(h("div", {}, [h(Component, {}, "baz")])).toEqual({
+    tag: "div",
+    data: {},
+    children: [
+      {
+        tag: "p",
+        data: {},
+        children: ["baz"]
       }
     ]
   })


### PR DESCRIPTION
This is an implementation of that discussed in here https://github.com/picodom/picodom/issues/26

It's very simple. Changes are:

- exports a new function called `setContext`
- all Components receive a third argument `(data, children, context)`

This third argument will be `null` in case `setContext` was never called, or it will be whatever you passed to `setContext`.

Tests have been added to keep coverage at 100%.

The use case is the same as explained in the [React documentation for context](https://facebook.github.io/react/docs/context.html):

> In some cases, you want to pass data through the component tree without having to pass the props down manually at every level.

Of course, this here is waaaaay more simple than context is in React.

If you like this, we can discuss a bit the naming (I don't really like `context` and would prefer something else) and merge it, since it's a very tiny change.

Otherwise, there's also the option of making it a separate package, like `picodom-context`, which would only export `{ h, setContext }`.

What do you think?