### PR TITLE
rename tag to type

### DIFF
--- a/picodom.d.ts
+++ b/picodom.d.ts
@@ -1,5 +1,5 @@
 export interface VirtualNode<Data> {
-  tag: string
+  type: string
   props?: Props
   children: VirtualNode<Props> | string
 }
@@ -9,7 +9,7 @@ export interface VirtualComponent<Props> {
 }
 
 export function h<Props>(
-  tag: VirtualComponent<Props> | string,
+  type: VirtualComponent<Props> | string,
   props?: Props,
   ...children: VirtualNode<Props> | string
 ): VirtualNode<Props>

--- a/src/h.js
+++ b/src/h.js
@@ -1,7 +1,7 @@
 var i
 var stack = []
 
-export function h(tag, props) {
+export function h(type, props) {
   var node
   var children = []
 
@@ -22,11 +22,11 @@ export function h(tag, props) {
     }
   }
 
-  return typeof tag === "string"
+  return typeof type === "string"
     ? {
-        tag: tag,
+        type: type,
         props: props || {},
         children: children
       }
-    : tag(props, children)
+    : type(props, children)
 }

--- a/src/h.js
+++ b/src/h.js
@@ -28,5 +28,5 @@ export function h(type, props) {
         props: props || {},
         children: children
       }
-    : type(props, children)
+    : type(props || {}, children)
 }

--- a/src/patch.js
+++ b/src/patch.js
@@ -9,10 +9,10 @@ export default function(oldNode, node, element, parent, cb) {
 function patch(parent, element, oldNode, node, isSVG, nextSibling) {
   if (oldNode == null) {
     element = parent.insertBefore(createElement(node, isSVG), element)
-  } else if (node.tag != null && node.tag === oldNode.tag) {
+  } else if (node.type != null && node.type === oldNode.type) {
     updateElement(element, oldNode.props, node.props)
 
-    isSVG = isSVG || node.tag === "svg"
+    isSVG = isSVG || node.type === "svg"
 
     var len = node.children.length
     var oldLen = oldNode.children.length
@@ -121,9 +121,9 @@ function createElement(node, isSVG) {
   if (typeof node === "string") {
     var element = document.createTextNode(node)
   } else {
-    var element = (isSVG = isSVG || node.tag === "svg")
-      ? document.createElementNS("http://www.w3.org/2000/svg", node.tag)
-      : document.createElement(node.tag)
+    var element = (isSVG = isSVG || node.type === "svg")
+      ? document.createElementNS("http://www.w3.org/2000/svg", node.type)
+      : document.createElement(node.type)
 
     if (node.props && node.props.oncreate) {
       globalInvokeLaterStack.push(function() {

--- a/test/h.test.js
+++ b/test/h.test.js
@@ -2,7 +2,7 @@ import { h } from "../src"
 
 test("empty vnode", () => {
   expect(h("div")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: []
   })
@@ -10,13 +10,13 @@ test("empty vnode", () => {
 
 test("vnode with a single child", () => {
   expect(h("div", {}, ["foo"])).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo"]
   })
 
   expect(h("div", {}, "foo")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo"]
   })
@@ -24,24 +24,24 @@ test("vnode with a single child", () => {
 
 test("positional String/Number children", () => {
   expect(h("div", {}, "foo", "bar", "baz")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["foo", "bar", "baz"]
   })
 
   expect(h("div", {}, 1, "foo", 2, "baz", 3)).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: ["1", "foo", "2", "baz", "3"]
   })
 
   expect(h("div", {}, "foo", h("div", {}, "bar"), "baz", "quux")).toEqual({
-    tag: "div",
+    type: "div",
     props: {},
     children: [
       "foo",
       {
-        tag: "div",
+        type: "div",
         props: {},
         children: ["bar"]
       },
@@ -61,7 +61,7 @@ test("vnode with data", () => {
   }
 
   expect(h("div", props, "baz")).toEqual({
-    tag: "div",
+    type: "div",
     props,
     children: ["baz"]
   })
@@ -69,7 +69,7 @@ test("vnode with data", () => {
 
 test("skip null and Boolean children", () => {
   const expected = {
-    tag: "div",
+    type: "div",
     props: {},
     children: []
   }
@@ -85,17 +85,17 @@ test("components", () => {
   const Component = (props, children) => h("div", props, children)
 
   expect(h(Component, { id: "foo" }, "bar")).toEqual({
-    tag: "div",
+    type: "div",
     props: { id: "foo" },
     children: ["bar"]
   })
 
   expect(h(Component, { id: "foo" }, [h(Component, { id: "bar" })])).toEqual({
-    tag: "div",
+    type: "div",
     props: { id: "foo" },
     children: [
       {
-        tag: "div",
+        type: "div",
         props: { id: "bar" },
         children: []
       }


### PR DESCRIPTION
Because hyperapp did it, so we should do it to so that vdom decorators that wish to be compatible with hyperapp and picodom can be.