### PR TITLE
set class-attribute from Object or Array values

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -57,6 +57,12 @@ function setElementProp(element, name, value, oldValue) {
     for (var name in merge(oldValue, (value = value || {}))) {
       element.style[name] = value[name] != null ? value[name] : ""
     }
+  } else if (name === "class" && typeof value === "object") {
+    let classNames = value.constructor == Object
+      ? Object.keys(value).filter(function(className) { return value[className] })
+      : value // assumes Array
+
+    element.setAttribute(name, classNames.join(" "))
   } else {
     try {
       element[name] = null == value ? "" : value

--- a/test/vdom.test.js
+++ b/test/vdom.test.js
@@ -604,6 +604,17 @@ testTrees("styles", [
   }
 ])
 
+testTrees("class names", [
+  {
+    node: h("div", { class: { foo: true, bar: true, qux: false } }),
+    html: `<div class="foo bar"></div>`
+  },
+  {
+    node: h("div", { class: ["foo", "bar"] }),
+    html: `<div class="foo bar"></div>`
+  }
+])
+
 testTrees("update element data", [
   {
     node: h("div", { id: "foo", class: "bar" }),


### PR DESCRIPTION
Add support for initializing the class-attribute from a map where class-name maps to `true`/`false` values, or from an Array of class-names.

This is very common and very widely-used feature in most JSX-based libraries - it gets a bit cumbersome to handhold this for every view implementation, and this shouldn't add much to the minified footprint, I think?
