### PR TITLE
Minor improvements to picodom.d.ts

### DIFF
--- a/picodom.d.ts
+++ b/picodom.d.ts
@@ -1,31 +1,31 @@
 export as namespace picodom
 
-export interface VNode<Props> {
+export interface VNode<Props = {}> {
   type: string
   props?: Props
-  children: Array<VNode<{}> | string>
+  children: Array<VNode | string>
 }
 
 export interface Component<Props = {}> {
-  (props: Props, children: Array<VNode<{}> | string>): VNode<Props>
+  (props: Props, children: Array<VNode | string>): VNode<Props>
 }
 
 export function h<Props>(
   type: Component<Props> | string,
   props?: Props,
-  ...children: Array<VNode<{}> | string | number | null>
+  ...children: Array<VNode | string | number | null>
 ): VNode<Props>
 
 export function h<Props>(
   tag: Component<Props> | string,
   props?: Props,
-  children?: Array<VNode<{}> | string | number | null>
+  children?: Array<VNode | string | number | null>
 ): VNode<Props>
 
 export function patch(
-  parent: HTMLElement,
-  oldNode: VNode<{}> | null,
-  newNode: VNode<{}>
+  parent: Element,
+  oldNode: VNode | null,
+  newNode: VNode
 ): Element
 
 declare global {


### PR DESCRIPTION
Use default type-argument of `{}` for VNode type, remove redundant type-arguments.

Also, make `patch` accept `Element` rather than `HTMLElement` - an `SVGElement` is not an `HTMLElement`, so this would get in the way of patching SVG element; it's also inconsistent with the return-type.

Closes #47 
