### PR TITLE
Add ondestroy & refactor functions in show order.

### DIFF
--- a/src/h.js
+++ b/src/h.js
@@ -12,8 +12,9 @@ export function h(type, props) {
       for (i = node.length; i--; ) {
         stack.push(node[i])
       }
-    } else if (node != null && node !== true && node !== false) {
-      children.push(typeof node === "number" ? (node = node + "") : node)
+    } else if (null == node || true === node || false === node) {
+    } else {
+      children.push(typeof node === "number" ? node + "" : node)
     }
   }
 

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -58,15 +58,14 @@ test("onremove", done => {
           [
             h("li"),
             h("li", {
-              onremove(element) {
+              onremove(element, remove) {
                 expect(document.body.innerHTML).toBe(
                   "<ul><li></li><li></li></ul>"
                 )
-                return remove => {
-                  remove()
-                  expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
-                  done()
-                }
+
+                remove()
+                expect(document.body.innerHTML).toBe("<ul><li></li></ul>")
+                done()
               }
             })
           ]
@@ -74,6 +73,28 @@ test("onremove", done => {
       : h("ul", {}, [h("li")])
 
   let node = view(true)
+  patch(document.body, null, node)
+  patch(document.body, node, view(false))
+})
+
+test("ondestroy", done => {
+  const view = state =>
+    state
+      ? h("ul", {}, [
+          h("li"),
+          h("li", {}, [
+            h("span", {
+              ondestroy() {
+                expect(document.body.innerHTML).toBe("<ul><li></li><li><span></span></li></ul>")
+                done()
+              }
+            })
+          ])
+        ])
+      : h("ul", {}, [h("li")])
+
+  let node = view(true)
+  
   patch(document.body, null, node)
   patch(document.body, node, view(false))
 })


### PR DESCRIPTION
- Add new ondestroy lifecycle event called both for nodes that are directly removed or removed as a result of a parent (any ancestor) node being removed.

- Breaking: Change the type of onremove from returning a function that receives `done`, to a function that takes both the element and `done`. onremove(element, done).

Sorry! I committed a bunch of unrelated stuff into this PR, but if I don't move fast, then picodom will never reach 2.0.