### PR TITLE
add recursive `ondestroy` notification

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -86,7 +86,9 @@ function updateElement(element, oldProps, props) {
   }
 }
 
-function removeElement(parent, element, props) {
+function removeElement(parent, element, node) {
+  var props = node.props
+
   if (
     props &&
     props.onremove &&
@@ -99,6 +101,17 @@ function removeElement(parent, element, props) {
 
   function remove() {
     parent.removeChild(element)
+    notifyDestroyed(node)
+  }
+}
+
+function notifyDestroyed(node) {
+  if (typeof node === "object") {
+    if (node.props.ondestroy) {
+      node.props.ondestroy(node)
+    }
+
+    node.children.map(notifyDestroyed)
   }
 }
 
@@ -176,7 +189,7 @@ function patchElement(parent, element, oldNode, node, isSVG, nextSibling) {
       var oldChild = oldNode.children[i]
       var oldKey = getKey(oldChild)
       if (null == oldKey) {
-        removeElement(element, oldElements[i], oldChild.props)
+        removeElement(element, oldElements[i], oldChild)
       }
       i++
     }
@@ -185,7 +198,7 @@ function patchElement(parent, element, oldNode, node, isSVG, nextSibling) {
       var keyedNode = oldKeyed[i]
       var reusableNode = keyedNode[1]
       if (!keyed[reusableNode.props.key]) {
-        removeElement(element, keyedNode[0], reusableNode.props)
+        removeElement(element, keyedNode[0], reusableNode)
       }
     }
   } else if (element && node !== element.nodeValue) {
@@ -196,7 +209,7 @@ function patchElement(parent, element, oldNode, node, isSVG, nextSibling) {
         createElement(node, isSVG),
         (nextSibling = element)
       )
-      removeElement(parent, nextSibling, oldNode.props)
+      removeElement(parent, nextSibling, oldNode)
     }
   }
   return element

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -78,6 +78,29 @@ test("onremove", done => {
   patch(document.body, node, view(false))
 })
 
+test("onremove vs ondestroy", done => {
+  var log = []
+  
+  var view = value =>
+    value
+      ? h("p", {id: "a", onremove: () => log.push("removed a"), ondestroy: () => log.push("destroyed a")}, [
+        h("p", {id: "b", onremove: () => log.push("removed b"), ondestroy: () => log.push("destroyed b")}, [
+          h("p", {id: "c", onremove: () => log.push("removed c"), ondestroy: () => log.push("destroyed c")})
+        ])
+      ])
+      : h("p", {id: "a", onremove: () => log.push("removed a"), ondestroy: () => log.push("destroyed a")})
+  
+  patch(document.body, null, view(true))
+
+  expect(log.length).toBe(0)
+
+  patch(document.body, view(true), view(false))
+
+  expect(log.join(', ')).toBe('removed b, destroyed b, destroyed c')
+
+  done()
+})
+
 test("event bubling", done => {
   var view = value =>
     h(


### PR DESCRIPTION
Fixes #61 

This addresses the need to integrate and clean up after third-party plain JS (or jQuery, etc.) components.

It's a temporary fix, in the sense that we know about the problems with `onremove` as it relates to `ondestroy` and the element order issue.

But I believe this gets me to the point where I can actually start to build a real project with picodom, seeing as how animation (via `onremove`) isn't really essential to shipping a functioning app.
