### PR TITLE
doesn't work?

### DIFF
--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -78,26 +78,26 @@ test("onremove", done => {
 })
 
 test("ondestroy", done => {
-  let removed = false
-
-  const view = state =>
-    state
-      ? h("ul", {}, [
-          h("li"),
-          h("li", {}, [
-            h("span", {
-              ondestroy() {
-                expect(removed).toBe(false)
-                done()
-              }
-            })
-          ])
+  var log = []
+  
+  var view = value =>
+    value
+      ? h("p", {id: "a", onremove: () => log.push("removed a"), ondestroy: () => log.push("destroyed a")}, [
+        h("p", {id: "b", onremove: () => log.push("removed b"), ondestroy: () => log.push("destroyed b")}, [
+          h("p", {id: "c", onremove: () => log.push("removed c"), ondestroy: () => log.push("destroyed c")})
         ])
-      : h("ul", {}, [h("li")])
+      ])
+      : h("p", {id: "a", onremove: () => log.push("removed a"), ondestroy: () => log.push("destroyed a")})
+  
+  patch(document.body, null, view(true))
 
-  let node = view(true)
-  patch(document.body, null, node)
-  patch(document.body, node, view(false))
+  expect(log.length).toBe(0)
+
+  patch(document.body, view(true), view(false))
+
+  expect(log.join(', ')).toBe('removed b, destroyed b, destroyed c')
+
+  done()
 })
 
 test("event bubling", done => {


### PR DESCRIPTION
@JorgeBucaran Was hoping to re-apply my changes to your branch, but... I noticed your test-case doesn't seem to be testing anything: you have a var `removed`, which you initialize as `false` - but that var is never changed, and the only assertion is to see if that var is `false`, so...

I replaced your test-case with the one from my branch, and it fails: it doesn't look like `ondestroy` is ever actually called? I can't figure out why.

I noticed one difference between your and my implementation, is you pass the about-to-be-destroyed HTML element to the handler - whereas my implementation passes the VNode instance. What I figured is, the element will *certainly* be destroyed at this point, so what use is it to a callback? Instead, I passed the VNode, which might contain other props or handlers that might be of interest - but if you wanted the actual element, you should be using `onremove`, I think?

In fact, I think I'd prefer to call `ondestroy` *after* the element has been removed, which would be consistent with `onupdate` which fires *after* the update, and `oncreate` which fires *after* creation.

If the only other thing you did was reorder the functions (it's really hard to tell from the diff) perhaps consider working from my branch instead? So that we get a clean commit with just the reordering - which shouldn't take long to do.
