### PR TITLE
improve and add missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,27 @@ const element = patch(
 
 The `patch` function returns the patched child element.
 
-## Reserved Attributes
+## Supported Attributes
 
-Picodom supports element-level life-cycle events and keyed updates, and reserves the following JSX attributes:
+This section describes the particular handling of certain HTML/SVG attributes, and certain special attributes reserved by Picodom.
+
+### Standard HTML and SVG Attributes
+
+All standard HTML and SVG attributes are supported, and the following standard attributes are handled specifically:
+
+#### `class`
+
+Both the `className`-property and `class`-attribute are supported.
+
+#### `style`
+
+This attribute expects a standard `object` rather than a `string` as in HTML.
+
+Individual style properties will be diffed and mapped against [`HTMLElement.style`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) property members of the DOM element - you should therefore use the [Javascript](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference) `style` object property names, e.g. `backgroundColor` rather than `background-color`.
+
+### Life-Cycle Attributes
+
+Picodom supports element-level life-cycle events and keyed updates via the following reserved attributes:
 
 #### `key`
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const element = patch(
 
 The `patch` function returns the patched child element.
 
-## Lifecycle Events
+## Reserved Attributes
 
 Picodom supports element-level life-cycle events and keyed updates, and reserves the following JSX attributes:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Picodom is a 1 KB VDOM builder and patch function.
 ```js
 import { h, patch } from "picodom"
 
+/** @jsx h */
+
 let node
 
 function render(view, state) {
@@ -79,35 +81,7 @@ function AwesomeTitle(text) {
 }
 ```
 
-### Lifecycle
-
-#### oncreate
-
-Fired after the element is created and attached to the DOM.
-
-<pre>
-<a id="oncreate-api"></a>oncreate(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>)
-</pre>
-
-#### onupdate
-
-Fired after the element attributes are updated. This event will fire even if the attributes have not changed.
-
-<pre>
-<a id="onupdate-api"></a>onupdate(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>, oldProps: <a href="#attributes">Attributes</a>)
-</pre>
-
-#### onremove
-
-Fired before the element is removed from the DOM. Return a function that takes a `remove()` function and use it to remove the element asynchronously.
-
-<pre>
-<a id="onremove-api"></a>onremove(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>)
-</pre>
-
-### patch
-
-Use `patch` to diff two nodes and update the DOM. `patch` returns the patched child element.
+To diff two virtual nodes and update the DOM, use the `patch` function:
 
 ```js
 const element = patch(
@@ -116,6 +90,60 @@ const element = patch(
   newNode  // the new VNode
 )
 ```
+
+The `patch` function returns the patched child element.
+
+## Lifecycle Events
+
+Picodom supports element-level life-cycle events and keyed updates, and reserves the following JSX attributes:
+
+#### `key`
+
+The `key` attribute enables Picodom to identify and preserve DOM elements, even when the order of child elements changes during an update.
+
+The value must be a string (or number) and it must be unique among all the siblings of a given child element.
+
+For example, use keys to ensure that input elements don't get replaced (and lose their focus or selection state, etc.) during updates - or for table rows (or other repeated elements) to ensure that these get reused.
+
+#### `oncreate`
+
+Fired after the element is created and attached to the DOM.
+
+<pre>
+<a id="oncreate-api"></a>oncreate(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>)
+</pre>
+
+#### `onupdate`
+
+Fired after the element attributes are updated. This event will fire even if the attributes have not changed.
+
+<pre>
+<a id="onupdate-api"></a>onupdate(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>, oldProps: <a href="#attributes">Attributes</a>)
+</pre>
+
+#### `onremove`
+
+Fired before the element is removed from the DOM.
+
+Your event handler will receive a reference to the element that is about to be removed, and a `done` callback function, which must be called to complete the removal, upon which the `ondestroy` handler will be fired.
+
+<pre>
+<a id="onremove-api"></a>onremove(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>, done)
+</pre>
+
+You can use this event to defer the physical removal of an element from the DOM, for purposes such as animation during removal.
+
+Note that the `onremove` event is only triggered for *direct* removals, e.g. for updates where the parent of the element still exists. For *indirect* removals (where the parent element was also removed) only the `ondestroy` event will fire.
+
+#### `ondestroy`
+
+Fired after the element is removed from the DOM.
+
+<pre>
+<a id="ondestroy-api"></a>ondestroy(<a href="https://developer.mozilla.org/en-US/docs/Web/API/Element">Element</a>)
+</pre>
+
+You can use this event to clean up after your `oncreate` handler - this enables you to integrate third-party widgets (date-pickers, content editors, etc.) and clean up after them.
 
 ## Links
 


### PR DESCRIPTION
Added the missing `ondestroy` event, updated the docs for the `onremove` event, clarified use of events with use-case examples, moved the `patch` function documentation up with the rest of the API description in the "Usage" section, documented the `key` attribute and when/how to use it, etc.