### PR TITLE
Add support for declarative shadow dom

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,17 @@ var patchNode = (parent, node, oldVNode, newVNode, isSvg) => {
       parent.removeChild(oldVNode.node)
     }
   } else {
+    if (parent.shadowRoot) {
+      patchNode(
+        parent.shadowRoot,
+        parent.shadowRoot.firstChild,
+        oldVNode,
+        newVNode,
+        isSvg
+      )
+      return // idk
+    }
+
     var tmpVKid,
       oldVKid,
       oldKey,

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var getKey = (vdom) => (vdom == null ? vdom : vdom.key)
 
 var patchProperty = (node, key, oldValue, newValue, isSvg) => {
   if (key === "key") {
-  } else if (key ==="shadow-root") {
+  } else if (key === "shadow-root") {
   } else if (key[0] === "o" && key[1] === "n") {
     if (
       !((node.events || (node.events = {}))[(key = key.slice(2))] = newValue)

--- a/index.js
+++ b/index.js
@@ -77,6 +77,14 @@ var patchNode = (parent, node, oldVNode, newVNode, isSvg) => {
     newVNode.type === TEXT_NODE
   ) {
     if (oldVNode.tag !== newVNode.tag) node.nodeValue = newVNode.tag
+  } else if (parent && parent.shadowRoot) {
+    return patchNode(
+      null,
+      parent.shadowRoot.firstChild,
+      oldVNode,
+      newVNode,
+      isSvg
+    )
   } else if (oldVNode == null || oldVNode.tag !== newVNode.tag) {
     node = parent.insertBefore(
       createNode((newVNode = vdomify(newVNode)), isSvg),
@@ -86,16 +94,6 @@ var patchNode = (parent, node, oldVNode, newVNode, isSvg) => {
       parent.removeChild(oldVNode.node)
     }
   } else {
-    if (parent.shadowRoot) {
-      return patchNode(
-        parent.shadowRoot,
-        parent.shadowRoot.firstChild,
-        oldVNode,
-        newVNode,
-        isSvg
-      )
-    }
-
     var tmpVKid,
       oldVKid,
       oldKey,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var getKey = (vdom) => (vdom == null ? vdom : vdom.key)
 
 var patchProperty = (node, key, oldValue, newValue, isSvg) => {
   if (key === "key") {
+  } if (key ==="shadow-root") {
   } else if (key[0] === "o" && key[1] === "n") {
     if (
       !((node.events || (node.events = {}))[(key = key.slice(2))] = newValue)
@@ -39,14 +40,12 @@ var createNode = (vdom, isSvg) => {
         : document.createElement(vdom.tag, { is: props.is }),
     attach = node,
     children = vdom.children,
-    mode = props['shadow-root']
 
-  if (mode) {
+  if (vdom.shadow) {
     const rootVNode = vdom.children[0]
     const root = document.createElement(rootVNode.tag)
 
-    node.attachShadow({ mode }).appendChild(root)
-    props['shadow-root'] = null
+    node.attachShadow({ mode: vdom.shadow }).appendChild(root)
 
     attach = root
     children = rootVNode.children
@@ -250,6 +249,7 @@ var createVNode = (tag, props, children, type, node) => ({
   tag,
   props,
   key: props.key,
+  shadow: props['shadow-root'],
   children,
   type,
   node,

--- a/index.js
+++ b/index.js
@@ -43,12 +43,7 @@ var createNode = (vdom, isSvg) => {
 
   if (vdom.shadow) {
     var rootVNode = vdom.children[0],
-      rootProps = rootVNode.props,
       root = document.createElement(rootVNode.tag)
-
-    for (var k in rootProps) {
-      patchProperty(root, k, null, rootProps[k], isSvg)
-    }
 
     node.attachShadow({ mode: vdom.shadow }).appendChild(root)
 
@@ -57,7 +52,7 @@ var createNode = (vdom, isSvg) => {
   }
 
   for (var k in props) {
-    patchProperty(node, k, null, props[k], isSvg)
+    patchProperty(attach, k, null, props[k], isSvg)
   }
 
   for (var i = 0; i < children.length; i++) {

--- a/index.js
+++ b/index.js
@@ -42,8 +42,13 @@ var createNode = (vdom, isSvg) => {
     children = vdom.children
 
   if (vdom.shadow) {
-    const rootVNode = vdom.children[0]
-    const root = document.createElement(rootVNode.tag)
+    var rootVNode = vdom.children[0],
+      rootProps = rootVNode.props,
+      root = document.createElement(rootVNode.tag)
+
+    for (var k in rootProps) {
+      patchProperty(root, k, null, rootProps[k], isSvg)
+    }
 
     node.attachShadow({ mode: vdom.shadow }).appendChild(root)
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var getKey = (vdom) => (vdom == null ? vdom : vdom.key)
 
 var patchProperty = (node, key, oldValue, newValue, isSvg) => {
   if (key === "key") {
-  } if (key ==="shadow-root") {
+  } else if (key ==="shadow-root") {
   } else if (key[0] === "o" && key[1] === "n") {
     if (
       !((node.events || (node.events = {}))[(key = key.slice(2))] = newValue)
@@ -39,7 +39,7 @@ var createNode = (vdom, isSvg) => {
         ? document.createElementNS(SVG_NS, vdom.tag, { is: props.is })
         : document.createElement(vdom.tag, { is: props.is }),
     attach = node,
-    children = vdom.children,
+    children = vdom.children
 
   if (vdom.shadow) {
     const rootVNode = vdom.children[0]

--- a/index.js
+++ b/index.js
@@ -87,14 +87,13 @@ var patchNode = (parent, node, oldVNode, newVNode, isSvg) => {
     }
   } else {
     if (parent.shadowRoot) {
-      patchNode(
+      return patchNode(
         parent.shadowRoot,
         parent.shadowRoot.firstChild,
         oldVNode,
         newVNode,
         isSvg
       )
-      return // idk
     }
 
     var tmpVKid,

--- a/index.js
+++ b/index.js
@@ -37,23 +37,28 @@ var createNode = (vdom, isSvg) => {
         : (isSvg = isSvg || vdom.tag === "svg")
         ? document.createElementNS(SVG_NS, vdom.tag, { is: props.is })
         : document.createElement(vdom.tag, { is: props.is }),
-    slot = node,
+    attach = node,
+    children = vdom.children,
     mode = props['shadow-root']
 
   if (mode) {
-    const root = document.createElement('div')
+    const rootVNode = vdom.children[0]
+    const root = document.createElement(rootVNode.tag)
+
     node.attachShadow({ mode }).appendChild(root)
     props['shadow-root'] = null
-    slot = root
+
+    attach = root
+    children = rootVNode.children
   }
 
   for (var k in props) {
     patchProperty(node, k, null, props[k], isSvg)
   }
 
-  for (var i = 0; i < vdom.children.length; i++) {
-    slot.appendChild(
-      createNode((vdom.children[i] = vdomify(vdom.children[i])), isSvg)
+  for (var i = 0; i < children.length; i++) {
+    attach.appendChild(
+      createNode((children[i] = vdomify(children[i])), isSvg)
     )
   }
 

--- a/index.js
+++ b/index.js
@@ -36,14 +36,23 @@ var createNode = (vdom, isSvg) => {
         ? document.createTextNode(vdom.tag)
         : (isSvg = isSvg || vdom.tag === "svg")
         ? document.createElementNS(SVG_NS, vdom.tag, { is: props.is })
-        : document.createElement(vdom.tag, { is: props.is })
+        : document.createElement(vdom.tag, { is: props.is }),
+    slot = node,
+    mode = props['shadow-root']
+
+  if (mode) {
+    const root = document.createElement('div')
+    node.attachShadow({ mode }).appendChild(root)
+    props['shadow-root'] = null
+    slot = root
+  }
 
   for (var k in props) {
     patchProperty(node, k, null, props[k], isSvg)
   }
 
   for (var i = 0; i < vdom.children.length; i++) {
-    node.appendChild(
+    slot.appendChild(
       createNode((vdom.children[i] = vdomify(vdom.children[i])), isSvg)
     )
   }


### PR DESCRIPTION
This addresses my issue #188.

This PR would allow you to write views that create `shadow-roots`. For example when using JSX:

```js
function view () {
  return <div>
    <h1>Heading 1</h1>
    <div>The styles inside this shadow-root below are completely scoped to that node. This pairs great with importing CSS from JavaScript imports.</div>
    <div shadow-root='open'>
      <h1>
        <style>{'h1 { display: flex; padding: 12px; color: white; background: dodgerblue; } div { padding: 0 24px; }'}</style>
        <button onclick={increment}>Increment</button>
        <div>{state.count}</div>
        <button onclick={decrement}>Decrement</button>
      </h1>
    </div>
  </div>
}
```

Where the DOM output would look like: (The root `h1` inside `shadow-root` is required to mount children into it and the parent `div` has to exist so we have a place to mount the `shadow-root` to.)

![image](https://user-images.githubusercontent.com/7419947/152022621-fcb75de7-8a1b-4398-83b4-d77c5463d10c.png)

Here's a codepen of the PR in action. <https://codepen.io/dustindowell/pen/rNYeLxg>

If this is not something you're interested in it's no problem! I just think it's really cool to have encapsulation of styles and scripts without having to touch the custom elements api!

To briefly walk over the changes.
  + I added a `slot` variable, because children will need to go into the `shadow-root` instead of the original node if the property `shadow-root` exists.
  + Inside the new condition, these are the minimum steps needed to create a new shadow node. Shadow root elements can only be a few different tags. The list of valid root tags can be found here: <https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow>. However the most common is obviously `<div>`. ~~I defaulted to `div` because I couldn't think of a good way to configure that. This is maybe something that could adjusted.~~ (see changes)
  + Finally, changing the `node.appendChild` to `slot.appendChild` so the children nodes are appended to the correct parent node.

EDIT: ~~Perhaps a solution to configuring the node you attach inside the `shadow-root` would be to not allow "fragments" inside a node which has a `shadow-root` property. I'll think about this and make some changes.~~ (see changes)

EDIT 2: ~~I also didn't account for patching. 😅  So I do have some work to do still.~~ (patching works fine)
